### PR TITLE
SC-249 Generate unique name for logs resources

### DIFF
--- a/azure/logs/template/resource_template.json
+++ b/azure/logs/template/resource_template.json
@@ -39,14 +39,14 @@
     },
     "functions": [],
     "variables": {
-        "eventHubNamespaceName": "[concat(parameters('projectName'), 'ns')]",
+        "eventHubNamespaceName": "[concat(parameters('projectName'), 'ns-', uniquestring(resourceGroup().id))]",
         "eventHubName": "[parameters('projectName')]",
 
         "connectionStringKey": "[concat('swi-',variables('eventHubNamespaceName'),'-AccessKey')]",
         "authRule": "[resourceId('Microsoft.EventHub/namespaces/authorizationRules', variables('eventHubNamespaceName'),'RootManageSharedAccessKey')]",
 
-        "storageAccountName": "[format('fnstor{0}', replace(parameters('projectName'), '-', ''))]",
-        "functionAppName": "[format('{0}-app', parameters('projectName'))]",
+        "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'swistoracc')]",
+        "functionAppName": "[concat(parameters('projectName'), '-app-', uniquestring(resourceGroup().id))]",
 
         "functionName": "[parameters('functionName')]"
     },

--- a/azure/logs/template/run.csx
+++ b/azure/logs/template/run.csx
@@ -13,13 +13,14 @@
 * under the License.
 */
 
-#r "Microsoft.Azure.EventHubs"
+#r "Azure.Messaging.EventHubs"
 #r "System.Text.Json"
+#r "System.Memory.Data"
 
 
 using System;
 using System.Text;
-using Microsoft.Azure.EventHubs;
+using Azure.Messaging.EventHubs;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
@@ -94,7 +95,7 @@ public static async Task Run(EventData[] events, ILogger logger)
     {
         try
         {
-            string messageBody = Encoding.UTF8.GetString(eventData.Body.Array, eventData.Body.Offset, eventData.Body.Count);
+            string messageBody = Encoding.UTF8.GetString(eventData.EventBody);
             logger.LogDebug($"C# Event Hub trigger function processed a message: {messageBody}");
 
             var log = JsonSerializer.Deserialize<dynamic>(messageBody);


### PR DESCRIPTION
Generating unique name for logs resources, because some of them must be unique across all tenants.