### PR TITLE
Change timeout for lambda function from 5 to 60 seconds

### DIFF
--- a/aws/logs/template.yaml
+++ b/aws/logs/template.yaml
@@ -19,7 +19,7 @@ Description: >
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
   Function:
-    Timeout: 5
+    Timeout: 60
 
 Parameters:
   OtlpEndpoint:


### PR DESCRIPTION
The lambda timeout set here has caused some issues sending logs to the OTEL endpoint in SWO. Increase the timeout for the lambda function to 60 seconds to accommodate larger payloads / latency.