### PR TITLE
Fix environment variable due to TLS failure with Otel

### DIFF
--- a/aws/logs/send-logs/main.go
+++ b/aws/logs/send-logs/main.go
@@ -48,7 +48,7 @@ const (
 
 const (
 	awsLambdaFunctionNameVar = "AWS_LAMBDA_FUNCTION_NAME"
-	awsExecutionEnvVar       = "AWS_EXECUTION_ENV"
+	awsLambdaInitTypeVar     = "AWS_LAMBDA_INITIALIZATION_TYPE"
 	awsRegionVar             = "AWS_REGION"
 	awsFunctionVersion       = "AWS_LAMBDA_FUNCTION_VERSION"
 	otlpEndpointVar          = "OTLP_ENDPOINT"
@@ -60,7 +60,7 @@ const (
 var (
 	runningTests                       = false
 	functionName                string = os.Getenv(awsLambdaFunctionNameVar)
-	executingInAWS              bool   = strings.Contains(os.Getenv(awsExecutionEnvVar), "AWS_Lambda_")
+	_, executingInAWS                  = os.LookupEnv(awsLambdaInitTypeVar)
 	lambdaRegion                string = os.Getenv(awsRegionVar)
 	lambdaVersion               string = os.Getenv(awsFunctionVersion)
 	useEncryption                      = executingInAWS && strings.EqualFold(os.Getenv(useEncryptionVar), "yes")

--- a/aws/logs/template.yaml
+++ b/aws/logs/template.yaml
@@ -8,7 +8,7 @@ Metadata:
     ReadmeUrl: README.md
     Labels: ['CloudWatch', 'Logs', 'AWS', 'Observability', 'OTEL']
     HomePageUrl: http://www.solarwinds.com
-    SemanticVersion: 0.0.10
+    SemanticVersion: 0.0.11
     SourceCodeUrl: https://github.com/solarwinds/cloud-observability-integration/tree/master/aws/logs
 
 AWSTemplateFormatVersion: '2010-09-09'


### PR DESCRIPTION
Environment variable AWS_EXECUTION_ENV does not exist in provided runtime. Alternatively best fallback options was AWS_LAMBDA_INITIALIZATION_TYPE to decide if the lambda is running on aws or not. TLS neg with Otel EP is decided on this.

ref: https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime